### PR TITLE
Fix ripple centering

### DIFF
--- a/src/ripple/main.styl
+++ b/src/ripple/main.styl
@@ -5,8 +5,8 @@ borderSize = 4px
   0%
     top: round(size * .5) - borderSize
     left: round(size * .5) - borderSize
-    width: 0
-    height: 0
+    width: borderSize * 2
+    height: borderSize * 2
     opacity: 1
   100%
     top: round(size * .05) - borderSize


### PR DESCRIPTION
At the beginning of the animation, the elements move from the right bottom corner to the center. This can be seen if you increase the animation time. I fixed this behavior and now the elements are centered.