### PR TITLE
fix: after element position in the center

### DIFF
--- a/src/dual-ring/main.styl
+++ b/src/dual-ring/main.styl
@@ -17,7 +17,7 @@ borderSize = size * .08
   display: block
   width: round(size * .8)
   height: round(size * .8)
-  margin: round(size * .1)
+  margin: round(size * 0.1 - borderSize / 2)
   border-radius: 50%
   border: round(borderSize) solid color.fg
   border-color: color.fg transparent color.fg transparent

--- a/src/dual-ring/main.styl
+++ b/src/dual-ring/main.styl
@@ -17,7 +17,7 @@ borderSize = size * .08
   display: block
   width: round(size * .8)
   height: round(size * .8)
-  margin: round(size * 0.1 - borderSize / 2)
+  margin: round(size * .1 - borderSize / 2)
   border-radius: 50%
   border: round(borderSize) solid color.fg
   border-color: color.fg transparent color.fg transparent


### PR DESCRIPTION
`lds-dual-ring`pseudo element `:after` default box-sizing is `content-border`.
So `margin-left` as example:
`margin-left` = `(size * (1 - 0.8) - borderSize) / 2` = `size * 0.1 - borderSize / 2`